### PR TITLE
Add `odiff.apply` implementation

### DIFF
--- a/odiff.d.ts
+++ b/odiff.d.ts
@@ -10,6 +10,7 @@ interface odiffResult {
 interface odiff {
     equal(a: any, b: any): boolean;
     similar(a: any, b: any): boolean;
+    apply(diff: odiffResult[], data: any): any;
 }
 
 declare function odiff(a: any, b: any): odiffResult[];

--- a/odiff.js
+++ b/odiff.js
@@ -139,6 +139,7 @@ var diffInternal = function(a,b,acc,base) {
 
 module.exports.similar = similar
 module.exports.equal = equal
+module.exports.apply = apply
 
 
 // finds and returns the closest indexes in a and b that match starting with divergenceIndex
@@ -268,6 +269,59 @@ function equal(a,b) {
     } else {
         return a===b || Number.isNaN(a) && Number.isNaN(b)
     }
+}
+
+
+function apply(diff,data) {
+    if (!diff || diff.path.length === 0) {
+        return data;
+    }
+    const result = data || (typeof diff.path[0] === 'number' ? [] : {});
+    var cursor = result;
+    // Prepare the cursor
+    var index;
+    var pathLen = diff.path.length;
+    for (index = 0; index < pathLen - 1; index++) {
+        var path = diff.path[index];
+        if (typeof cursor[path] === 'undefined') {
+            cursor[path] = typeof path === 'number' ? [] : {};
+        }
+            cursor = cursor[path];
+    }
+    var lastPath = diff.path[index];
+    // Perform the diff operation
+    switch (diff.type) {
+    case 'SET':
+        cursor[lastPath] = diff.val;
+        break;
+    case 'UNSET':
+        delete cursor[lastPath];
+        break;
+    case 'ADD': {
+        if (typeof cursor[lastPath] === 'undefined') {
+            cursor[lastPath] = [];
+        }
+        const cursorAsArray = cursor[lastPath] as any[];
+        cursor[lastPath] = cursorAsArray
+            .slice(0, diff.index)
+            .concat(diff.vals)
+            .concat(cursorAsArray.slice(diff.index));
+        break;
+    }
+    case 'RM':
+        if (typeof cursor[lastPath] === 'undefined') {
+            cursor[lastPath] = [];
+        } else {
+            (cursor[lastPath] as any[]).splice(
+                diff.index as number,
+                diff.rm.length,
+            );
+        }
+        break;
+    default:
+        throw new Error(`Unsupported diff operation: ${diff.type}`);
+    }
+    return result;
 }
 
 


### PR DESCRIPTION
Hi!

First of all thank you for `odiff`, the differences it produces saved my day at work :D

I found myself needing to apply a diff array to an object and I made the implementation in this PR.

Before adding tests and what not I wanted to ask why odiff doesn't have an `apply` already and if the implementation in here makes sense.

Thanks!